### PR TITLE
chore: update to libdns/libdns v0.2.2 - fix build errors with caddy v2.8.0+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/libdns/directadmin
 
 go 1.18
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.2
 
 require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/models.go
+++ b/models.go
@@ -50,7 +50,7 @@ func (r daRecord) libdnsRecord(zone string) (libdns.Record, error) {
 	case "MX":
 		splits := strings.Split(r.Value, " ")
 
-		priority, err := strconv.Atoi(splits[0])
+		uint(priority), err := strconv.Atoi(splits[0])
 		if err != nil {
 			return record, fmt.Errorf("failed to parse MX priority for %v: %v", r.Name, err)
 		}

--- a/models.go
+++ b/models.go
@@ -50,12 +50,12 @@ func (r daRecord) libdnsRecord(zone string) (libdns.Record, error) {
 	case "MX":
 		splits := strings.Split(r.Value, " ")
 
-		uint(priority), err := strconv.Atoi(splits[0])
+		priority, err := strconv.Atoi(splits[0])
 		if err != nil {
 			return record, fmt.Errorf("failed to parse MX priority for %v: %v", r.Name, err)
 		}
 
-		record.Priority = priority
+		record.Priority = uint(priority)
 		record.Value = fmt.Sprintf("%v.%v", splits[1], zone)
 	case "SRV":
 		return record, ErrUnsupported


### PR DESCRIPTION
Compare to:
https://github.com/libdns/netcup/pull/1
https://github.com/caddy-dns/netcup/pull/6

